### PR TITLE
fix: correct negative durations and channel element ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ func main() {
 	p := &podcasts.Podcast{
 		Title:       "My podcast",
 		Description: "This is my very simple podcast.",
-		Language:    "EN",
+		Language:    "en",
 		Link:        "http://www.example-podcast.com/my-podcast",
 		Copyright:   "2015 My podcast copyright",
 	}
@@ -48,7 +48,7 @@ func main() {
 		Enclosure: &podcasts.Enclosure{
 			URL:    "http://www.example-podcast.com/my-podcast/1/episode.mp3",
 			Length: "12312",
-			Type:   "MP3",
+			Type:   "audio/mpeg",
 		},
 	})
 
@@ -61,7 +61,7 @@ func main() {
 		Enclosure: &podcasts.Enclosure{
 			URL:    "http://www.example-podcast.com/my-podcast/2/episode.mp3",
 			Length: "46732",
-			Type:   "MP3",
+			Type:   "audio/mpeg",
 		},
 	})
 
@@ -92,12 +92,12 @@ Which gives us this XML output:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
   <channel>
     <title>My podcast</title>
     <link>http://www.example-podcast.com/my-podcast</link>
     <copyright>2015 My podcast copyright</copyright>
-    <language>EN</language>
+    <language>en</language>
     <description>This is my very simple podcast.</description>
     <itunes:author>Author Name</itunes:author>
     <itunes:block>yes</itunes:block>
@@ -116,14 +116,14 @@ Which gives us this XML output:
       <guid>http://www.example-podcast.com/my-podcast/1/episode-one</guid>
       <pubDate>Tue, 10 Nov 2009 23:00:00 +0000</pubDate>
       <itunes:duration>3:50</itunes:duration>
-      <enclosure url="http://www.example-podcast.com/my-podcast/1/episode.mp3" length="12312" type="MP3"></enclosure>
+      <enclosure url="http://www.example-podcast.com/my-podcast/1/episode.mp3" length="12312" type="audio/mpeg"></enclosure>
     </item>
     <item>
       <title>Episode 2</title>
       <guid>http://www.example-podcast.com/my-podcast/2/episode-two</guid>
       <pubDate>Tue, 10 Nov 2009 23:00:00 +0000</pubDate>
       <itunes:duration>5:20</itunes:duration>
-      <enclosure url="http://www.example-podcast.com/my-podcast/2/episode.mp3" length="46732" type="MP3"></enclosure>
+      <enclosure url="http://www.example-podcast.com/my-podcast/2/episode.mp3" length="46732" type="audio/mpeg"></enclosure>
     </item>
   </channel>
 </rss>

--- a/doc.go
+++ b/doc.go
@@ -5,7 +5,7 @@ Package podcasts implements a podcast generator.
 	p := &podcasts.Podcast{
 	    Title:       "My podcast",
 	    Description: "This is my very simple podcast.",
-	    Language:    "EN",
+	    Language:    "en",
 	    Link:        "http://www.example-podcast.com/my-podcast",
 	    Copyright:   "2015 My podcast copyright",
 	}
@@ -19,7 +19,7 @@ Package podcasts implements a podcast generator.
 	    Enclosure: &podcasts.Enclosure{
 	        URL:    "http://www.example-podcast.com/my-podcast/1/episode.mp3",
 	        Length: "12312",
-	        Type:   "MP3",
+	        Type:   "audio/mpeg",
 	    },
 	})
 
@@ -32,7 +32,7 @@ Package podcasts implements a podcast generator.
 	    Enclosure: &podcasts.Enclosure{
 	        URL:    "http://www.example-podcast.com/my-podcast/2/episode.mp3",
 	        Length: "46732",
-	        Type:   "MP3",
+	        Type:   "audio/mpeg",
 	    },
 	})
 

--- a/feed.go
+++ b/feed.go
@@ -60,21 +60,32 @@ func (d Duration) MarshalXML(encoder *xml.Encoder, start xml.StartElement) error
 }
 
 // formatDuration formats duration in these formats: HH:MM:SS, H:MM:SS, MM:SS, M:SS.
+// A negative duration is formatted as its magnitude behind a minus sign, the same
+// way time.Duration.String does, so that a caller mistake is visible in the feed
+// instead of being silently turned into a plausible looking value.
 func formatDuration(d time.Duration) string {
+	var builder strings.Builder
+
 	total := int(d.Seconds())
+	if total < 0 {
+		builder.WriteString("-")
+		total = -total
+	}
+
 	hours := total / 3600
 	total %= 3600
 	minutes := total / 60
 	total %= 60
 
-	var builder strings.Builder
 	if hours > 0 {
-		builder.WriteString(strconv.Itoa(hours) + ":")
+		builder.WriteString(strconv.Itoa(hours))
+		builder.WriteString(":")
 	}
 	if hours > 0 && minutes < 10 {
 		builder.WriteString("0")
 	}
-	builder.WriteString(strconv.Itoa(minutes) + ":")
+	builder.WriteString(strconv.Itoa(minutes))
+	builder.WriteString(":")
 	if total < 10 {
 		builder.WriteString("0")
 	}
@@ -153,8 +164,10 @@ type Channel struct {
 	Summary     *CDATAText `xml:"itunes:summary,omitempty"`
 	Owner       *ItunesOwner
 	Image       *ItunesImage
-	Items       []*Item
 	Categories  []*ItunesCategory
+	// Items is last so that every channel level element is marshalled before
+	// the episodes, as encoding/xml writes fields in declaration order.
+	Items []*Item
 }
 
 // Feed wraps the given RSS channel.
@@ -210,6 +223,15 @@ var (
 	}
 )
 
+// putBuffer returns a buffer to the pool, emptying it first so that the pool
+// only ever holds buffers that are safe to hand straight back out. Callers that
+// read the buffer rather than draining it, and error paths that abandon it part
+// written, would otherwise leave their contents behind.
+func putBuffer(buf *bytes.Buffer) {
+	buf.Reset()
+	bufferPool.Put(buf)
+}
+
 // WriteOptions defines options for XML writing
 type WriteOptions struct {
 	// BufferSize sets the initial buffer size for large feeds
@@ -226,7 +248,7 @@ func (f *Feed) WriteWithOptions(writer io.Writer, opts WriteOptions) error {
 	if opts.UsePool {
 		buf = bufferPool.Get().(*bytes.Buffer)
 		buf.Reset()
-		defer bufferPool.Put(buf)
+		defer putBuffer(buf)
 	} else if opts.BufferSize > 0 {
 		buf = &bytes.Buffer{}
 		buf.Grow(opts.BufferSize)
@@ -453,7 +475,7 @@ func (f *Feed) XMLWithOptions(opts WriteOptions) (string, error) {
 	if opts.UsePool {
 		buf = bufferPool.Get().(*bytes.Buffer)
 		buf.Reset()
-		defer bufferPool.Put(buf)
+		defer putBuffer(buf)
 	} else {
 		buf = &bytes.Buffer{}
 		if opts.BufferSize > 0 {

--- a/feed_test.go
+++ b/feed_test.go
@@ -147,6 +147,18 @@ func TestDurationMarshalling(t *testing.T) {
 			dur:  time.Second * 37000,
 			want: "<Duration>10:16:40</Duration>",
 		},
+		{
+			dur:  time.Second * -6,
+			want: "<Duration>-0:06</Duration>",
+		},
+		{
+			dur:  time.Second * -90,
+			want: "<Duration>-1:30</Duration>",
+		},
+		{
+			dur:  time.Second * -3665,
+			want: "<Duration>-1:01:05</Duration>",
+		},
 	}
 
 	for _, testCase := range cases {

--- a/podcast_test.go
+++ b/podcast_test.go
@@ -302,6 +302,37 @@ func TestContainsItemElements(t *testing.T) {
 	}
 }
 
+func TestChannelMetadataPrecedesItems(t *testing.T) {
+	podcast := setupPodcast()
+	feed, err := podcast.Feed(Image("http://www.example-podcast.com/my-podcast.jpg"))
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	feed.Channel.Categories = []*ItunesCategory{{Text: "Technology"}}
+
+	data, err := feed.XML()
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	firstItem := strings.Index(data, "<item>")
+	if firstItem < 0 {
+		t.Fatal("expected the feed to contain items")
+	}
+
+	for _, element := range []string{"<itunes:image", "<itunes:category"} {
+		t.Run(element, func(t *testing.T) {
+			at := strings.Index(data, element)
+			if at < 0 {
+				t.Fatalf("expected the feed to contain %s", element)
+			}
+			if at > firstItem {
+				t.Errorf("expected %s to be written before the first item", element)
+			}
+		})
+	}
+}
+
 func TestPodcastFeedWrite(t *testing.T) {
 	podcast := &Podcast{}
 	feed, err := podcast.Feed()


### PR DESCRIPTION
Three defects found while reviewing the library, plus the doc corrections that go with them.

## Negative durations produced malformed output

`formatDuration` used integer division and modulo, which keep the sign of the operand, so every component went negative and the zero-padding branch fired on a negative number:

```go
NewDuration(-90 * time.Second)  →  <itunes:duration>-1:0-30</itunes:duration>
```

The magnitude is now formatted behind a single minus sign, matching `time.Duration.String`, so a caller mistake is visible in the feed instead of being silently turned into a plausible looking value. `TestDurationMarshalling` gains negative cases.

## `itunes:category` was written after the items

`Channel.Items` was declared before `Channel.Categories`, and `encoding/xml` marshals struct fields in declaration order, so channel level category metadata landed after every episode. `Items` now sorts last, which puts all channel metadata ahead of the episodes and matches what `StreamWrite` already did. `TestChannelMetadataPrecedesItems` covers it.

## Pooled buffers were returned dirty

`XMLWithOptions` reads its buffer with `String` rather than draining it, and both write paths abandon a part written buffer on the error path, so `bufferPool` could hand out buffers with contents still in them. A new `putBuffer` helper empties them on the way back in.

This was also making `TestBufferAndStringBuilderPools` fail depending on test ordering — reproducible on `main` at roughly one run in five under `-race`, and it would have made this branch's CI intermittently red.

## Docs

The README and the package example advertised `Type: "MP3"` and `Language: "EN"`. Those fields are a MIME type and an RFC 5646 tag, so anyone copy-pasting the example shipped a broken feed; they are now `audio/mpeg` and `en`. The README's sample XML output was also stale (it predated the `xmlns:content` attribute), and has been regenerated from the library itself.

## Verification

- `mise run check-all` clean
- `mise run test` (race) green over eight consecutive runs, where `main` was flaky
- coverage 84.1%, above the 80% floor