### PR TITLE
build!: require Go 1.25

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -30,7 +30,7 @@ func TestFuzzURLValidation(t *testing.T) {
 	}
 
 	for _, testURL := range testCases {
-		t.Run("URL_"+testURL[:minInt(len(testURL), 20)], func(t *testing.T) {
+		t.Run("URL_"+testURL[:min(len(testURL), 20)], func(t *testing.T) {
 			// These should all either return an error or be handled gracefully
 			err1 := NewFeedURL(testURL)(feed)
 			err2 := Image(testURL)(feed)
@@ -66,7 +66,7 @@ func TestFuzzStringFields(t *testing.T) {
 	}
 
 	for _, testStr := range testStrings {
-		t.Run("String_"+testStr[:minInt(len(testStr), 20)], func(t *testing.T) {
+		t.Run("String_"+testStr[:min(len(testStr), 20)], func(t *testing.T) {
 			// Test all string-accepting functions
 			_ = Author(testStr)(feed)
 			_ = Subtitle(testStr)(feed)
@@ -175,13 +175,6 @@ func TestFuzzPodcastCreation(t *testing.T) {
 }
 
 // Helper functions for fuzzing tests
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func isValidAbsoluteURL(urlStr string) bool {
 	if urlStr == "" {
 		return false

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/CallumKerson/podcasts
 
-go 1.17
+go 1.25


### PR DESCRIPTION
Second of the breaking changes for 2.0.0. **Stacked on #32** — review that first; this PR's diff is against it.

## Why

`go.mod` declared `go 1.17`, released in 2021 and long out of support. Nothing in the module needed that compatibility, and it held back the `modernize` linter (already enabled in `.golangci.toml`) from the language features it checks for.

`1.25` keeps the module buildable on every Go release upstream still supports — Go's policy covers the two most recent — and matches the toolchain the repo already pins via mise (`go = "1.26.5"`).

## What it buys immediately

Dropping the hand-written `minInt` helper in the fuzz tests for the `min` builtin (Go 1.21+).

The `interface{}` → `any` rewrite I originally scoped into this change turned out to be moot: all four occurrences lived in the performance API, so #32 removed them. Doing this PR first would have converted them and then deleted them, which is why the two are in this order.

## Notes

- `golangci-lint` reports 0 issues at the new version — no further modernisations were flagged.
- If 1.25 is tighter than you want for a library, the directive is a one-line change; 1.24 or 1.23 would still support `min`. I picked 1.25 to match Go's own support window.