### PR TITLE
refactor!: give the podcast accessors idiomatic names

### DIFF
--- a/podcast.go
+++ b/podcast.go
@@ -34,19 +34,16 @@ func (p *Podcast) Feed(options ...func(f *Feed) error) (*Feed, error) {
 	return feed, err
 }
 
-// GetItemCount returns the number of items in the podcast
-func (p *Podcast) GetItemCount() int {
+// Len returns the number of items in the podcast.
+func (p *Podcast) Len() int {
 	return len(p.items)
 }
 
-// GetItems returns a copy of the items slice (safe for concurrent access)
-func (p *Podcast) GetItems() []*Item {
+// Items returns a copy of the podcast items, so that callers cannot reach the
+// slice the podcast builds its feed from. A Podcast is not safe for concurrent
+// use: guard it yourself if one goroutine may call AddItem while another reads.
+func (p *Podcast) Items() []*Item {
 	items := make([]*Item, len(p.items))
 	copy(items, p.items)
 	return items
-}
-
-// GetItemsSlice returns the items slice directly (unsafe for concurrent modification)
-func (p *Podcast) GetItemsSlice() []*Item {
-	return p.items
 }

--- a/podcast_test.go
+++ b/podcast_test.go
@@ -530,7 +530,7 @@ func TestPodcastMethods(t *testing.T) {
 	}
 
 	// Test initial state
-	if podcast.GetItemCount() != 0 {
+	if podcast.Len() != 0 {
 		t.Error("Initial item count should be 0")
 	}
 
@@ -549,30 +549,23 @@ func TestPodcastMethods(t *testing.T) {
 	podcast.AddItem(item1)
 	podcast.AddItem(item2)
 
-	if podcast.GetItemCount() != 2 {
-		t.Errorf("Expected 2 items, got %d", podcast.GetItemCount())
+	if podcast.Len() != 2 {
+		t.Errorf("Expected 2 items, got %d", podcast.Len())
 	}
 
-	// Test GetItems (safe copy)
-	items := podcast.GetItems()
+	items := podcast.Items()
 	if len(items) != 2 {
-		t.Errorf("Expected 2 items from GetItems, got %d", len(items))
+		t.Errorf("Expected 2 items from Items, got %d", len(items))
 	}
 
-	// Modify the returned slice - should not affect original
+	// Modifying the returned slice must not reach the podcast
 	items[0] = nil
 
-	// Test GetItemsSlice (direct reference)
-	directItems := podcast.GetItemsSlice()
-	if len(directItems) != 2 {
-		t.Errorf("Expected 2 items from GetItemsSlice, got %d", len(directItems))
+	again := podcast.Items()
+	if again[0] == nil {
+		t.Error("Items should return a copy, not the underlying slice")
 	}
-
-	// Original items should be unchanged
-	if directItems[0] == nil {
-		t.Error("Direct items slice should not be affected by copy modification")
-	}
-	if directItems[0].Title != "Item 1" {
+	if again[0].Title != "Item 1" {
 		t.Error("First item title should be unchanged")
 	}
 
@@ -582,7 +575,7 @@ func TestPodcastMethods(t *testing.T) {
 		PubDate: NewPubDate(time.Now()),
 	})
 
-	if podcast.GetItemCount() != 3 {
-		t.Errorf("Expected 3 items, got %d", podcast.GetItemCount())
+	if podcast.Len() != 3 {
+		t.Errorf("Expected 3 items, got %d", podcast.Len())
 	}
 }


### PR DESCRIPTION
Third of the breaking changes for 2.0.0. **Stacked on #33** (which is stacked on #32) — this PR's diff is against #33.

## Renames

| Before | After |
|---|---|
| `Podcast.GetItemCount()` | `Podcast.Len()` |
| `Podcast.GetItems()` | `Podcast.Items()` |
| `Podcast.GetItemsSlice()` | *removed* |

Go doesn't put `Get` in front of accessors, and `Len` is the conventional spelling for a count.

## `GetItemsSlice` is gone

It handed out the very slice the podcast builds its feed from, and its own comment admitted it was "unsafe for concurrent modification". It existed only to skip the copy `Items` makes — not a trade worth an exported method on a type this small. Callers wanting the copy use `Items()`.

## Corrected a misleading doc comment

`GetItems` claimed its copy made it "safe for concurrent access". It doesn't — copying the slice header while another goroutine `append`s to it is a data race, and nothing in `Podcast` is synchronised. This was the one item from my original review that never got its own slot; since this PR rewrites that exact comment, it's fixed here.

`Items` now says what the copy is really for (callers can't reach the internal slice) and states plainly that a `Podcast` needs external synchronisation.

## Notes

- Coverage 95.4%; race suite green.
- With this merged, items 5, 6 and 7 are all done. The `/v2` module path PR follows.