### PR TITLE
build!: move the module to the /v2 import path

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -85,7 +85,7 @@ enable = ["gci", "gofumpt", "golines"]
 sections = ["standard", "default", "localmodule"]
 
 [formatters.settings.gofumpt]
-module-path = "github.com/CallumKerson/podcasts"
+module-path = "github.com/CallumKerson/podcasts/v2"
 extra-rules = true
 
 [formatters.settings.golines]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Podcast generator written in Go.
 ## Install
 
 ```bash
-go get github.com/CallumKerson/podcasts
+go get github.com/CallumKerson/podcasts/v2
 ```
 
 ## Go Docs
@@ -26,7 +26,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/CallumKerson/podcasts"
+	"github.com/CallumKerson/podcasts/v2"
 )
 
 func main() {
@@ -132,6 +132,46 @@ Which gives us this XML output:
 ## Options
 
 For further options and configuration, please see the [options docs](./docs/options.md).
+
+## Upgrading from v1
+
+v2 requires Go 1.25 or newer, and the import path gains a `/v2` suffix:
+
+```go
+import "github.com/CallumKerson/podcasts/v2"
+```
+
+The performance API was removed after benchmarking showed it made feed
+generation no faster. `Feed.Write` and `Feed.XML` are unchanged; wrap the writer
+where buffering matters:
+
+```go
+// before
+err := feed.WriteWithOptions(w, WriteOptions{UsePool: true, BufferSize: 8192})
+
+// after
+bw := bufio.NewWriter(w)
+if err := feed.Write(bw); err != nil {
+    return err
+}
+return bw.Flush()
+```
+
+| Removed                    | Use instead                    |
+| -------------------------- | ------------------------------ |
+| `Feed.StreamWrite`         | `Feed.Write`                   |
+| `Feed.WriteWithOptions`    | `Feed.Write`                   |
+| `Feed.XMLWithOptions`      | `Feed.XML`                     |
+| `WriteOptions`             | —                              |
+| `GetBufferPool`            | —                              |
+| `GetStringBuilderPool`     | —                              |
+| `Podcast.AddItemWithCapacity` | `Podcast.AddItem`           |
+| `Podcast.GetItemCount`     | `Podcast.Len`                  |
+| `Podcast.GetItems`         | `Podcast.Items`                |
+| `Podcast.GetItemsSlice`    | `Podcast.Items`                |
+
+Negative `Duration` values now marshal as `-1:30` rather than the malformed
+`-1:0-30`, and `itunes:category` is written before the items rather than after.
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/CallumKerson/podcasts
+module github.com/CallumKerson/podcasts/v2
 
 go 1.25


### PR DESCRIPTION
Final piece of the 2.0.0 prep. **Stacked on #34** (→ #33 → #32).

## Why this is mandatory, not cosmetic

Go requires the major version in the module path from v2 onwards. Tagging `v2.0.0` while `go.mod` still says `module github.com/CallumKerson/podcasts` produces a tag nobody can consume — the module proxy rejects a major version the path doesn't carry, and `go get` refuses to resolve it. The other three PRs are the breaking changes; this is what makes them releasable as a major version.

## Changes

- `go.mod`: `module github.com/CallumKerson/podcasts/v2`
- `README.md`: install command and example import
- `.golangci.toml`: the `gofumpt` `module-path` setting had the old path hard-coded
- A new **Upgrading from v1** section in the README, with a removed/replacement table covering all of #32, #33 and #34, plus the `WriteWithOptions` → `bufio.Writer` migration

## Verified

Built a throwaway consumer module outside the repo, requiring `github.com/CallumKerson/podcasts/v2` via a `replace`, and ran it end to end — the `/v2` import resolves, the renamed `Len()`/`Items()` accessors work, and a feed with a 90s duration renders `1:30`:

```
Len=1 Items=1
<?xml version="1.0" encoding="UTF-8"?>
<rss xmlns:itunes="..." xmlns:content="..." version="2.0">
  ...
      <itunes:duration>1:30</itunes:duration>
```

`go test` now reports the package as `github.com/CallumKerson/podcasts/v2`.

## After this merges

All four PRs carry `!` / `BREAKING CHANGE:` footers, so release-please should accumulate them into a single **2.0.0** release PR rather than tagging each one. Worth confirming the release PR says 2.0.0 (not 1.2.0) before merging it — that's the signal the footers were picked up.