### PR TITLE
feat: add Category option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ func main() {
 		podcasts.Summary("This is my very simple podcast summary."),
 		podcasts.Owner("Podcast Owner", "owner@example-podcast.com"),
 		podcasts.Image("http://www.example-podcast.com/my-podcast.jpg"),
+		podcasts.Category("Technology"),
 	)
 
 	// handle error
@@ -111,6 +112,7 @@ Which gives us this XML output:
       <itunes:email>owner@example-podcast.com</itunes:email>
     </itunes:owner>
     <itunes:image href="http://www.example-podcast.com/my-podcast.jpg"></itunes:image>
+    <itunes:category text="Technology"></itunes:category>
     <item>
       <title>Episode 1</title>
       <guid>http://www.example-podcast.com/my-podcast/1/episode-one</guid>

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,7 +1,7 @@
 # Configuration Options
 
 This document describes the various ways to configure the podcasts library,
-including feed metadata options and performance optimizations.
+covering the feed metadata options and how to write the finished feed.
 
 ## Feed Configuration Options
 
@@ -91,6 +91,38 @@ feed, err := podcast.Feed(Image("https://example.com/podcast-art.jpg"))
 - URL must be absolute (validated at runtime)
 - Large images may slow feed parsing
 - Recommended: 1400x1400 to 3000x3000 pixels, JPEG/PNG
+
+#### `Category(name string, subcategories ...string)`
+
+Adds an `itunes:category`, nesting any subcategories inside it.
+
+**When to use:** Always, for a feed you intend to submit to a directory.
+Apple requires at least one category, and uses it to decide where the podcast is listed.
+
+**Example:**
+
+```go
+feed, err := podcast.Feed(
+    Category("Technology"),
+    Category("Society & Culture", "Documentary", "Personal Journals"),
+)
+```
+
+```xml
+<itunes:category text="Technology"></itunes:category>
+<itunes:category text="Society &amp; Culture">
+  <itunes:category text="Documentary"></itunes:category>
+  <itunes:category text="Personal Journals"></itunes:category>
+</itunes:category>
+```
+
+A feed may carry more than one category, so each call appends rather than replacing what is already there.
+
+**Downsides:**
+
+- Names are not checked against Apple's category list, which changes without notice, so a typo is only caught when the feed is submitted.
+  Use the names the target directory publishes.
+- An empty name or subcategory returns `ErrInvalidCategory`.
 
 ### Content Control Options
 

--- a/options.go
+++ b/options.go
@@ -11,6 +11,9 @@ var (
 
 	// ErrInvalidImage represents a error returned for invalid image.
 	ErrInvalidImage = errors.New("podcasts: invalid image")
+
+	// ErrInvalidCategory represents a error returned for invalid category.
+	ErrInvalidCategory = errors.New("podcasts: invalid category")
 )
 
 const (
@@ -82,6 +85,30 @@ func Owner(name, email string) func(feed *Feed) error {
 			Name:  name,
 			Email: email,
 		}
+		return nil
+	}
+}
+
+// Category adds an itunes:category to the given feed, nesting any
+// subcategories inside it. A feed may carry more than one category, so each
+// call appends rather than replacing what is already there.
+//
+// The names are not checked against Apple's category list, which changes
+// without notice; a feed submitted to a directory needs to use the names that
+// directory publishes.
+func Category(name string, subcategories ...string) func(feed *Feed) error {
+	return func(feed *Feed) error {
+		if name == "" {
+			return ErrInvalidCategory
+		}
+		category := &ItunesCategory{Text: name}
+		for _, subcategory := range subcategories {
+			if subcategory == "" {
+				return ErrInvalidCategory
+			}
+			category.Categories = append(category.Categories, &ItunesCategory{Text: subcategory})
+		}
+		feed.Channel.Categories = append(feed.Channel.Categories, category)
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -152,6 +152,81 @@ func TestImage(t *testing.T) {
 	}
 }
 
+func TestCategory(t *testing.T) {
+	feed := &Feed{
+		Channel: &Channel{},
+	}
+	if err := Category("Technology")(feed); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if len(feed.Channel.Categories) != 1 {
+		t.Fatalf("expected 1 category got %v", len(feed.Channel.Categories))
+	}
+	if want := "Technology"; feed.Channel.Categories[0].Text != want {
+		t.Errorf("expected %v got %v", want, feed.Channel.Categories[0].Text)
+	}
+	if got := feed.Channel.Categories[0].Categories; len(got) != 0 {
+		t.Errorf("expected no subcategories got %v", len(got))
+	}
+}
+
+func TestCategoryWithSubcategories(t *testing.T) {
+	feed := &Feed{
+		Channel: &Channel{},
+	}
+	if err := Category("Society & Culture", "Documentary", "Personal Journals")(feed); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if len(feed.Channel.Categories) != 1 {
+		t.Fatalf("expected 1 category got %v", len(feed.Channel.Categories))
+	}
+
+	subcategories := feed.Channel.Categories[0].Categories
+	if len(subcategories) != 2 {
+		t.Fatalf("expected 2 subcategories got %v", len(subcategories))
+	}
+	for i, want := range []string{"Documentary", "Personal Journals"} {
+		if subcategories[i].Text != want {
+			t.Errorf("expected %v got %v", want, subcategories[i].Text)
+		}
+	}
+}
+
+func TestCategoryAppends(t *testing.T) {
+	feed := &Feed{
+		Channel: &Channel{},
+	}
+	if err := feed.SetOptions(Category("Technology"), Category("News", "Tech News")); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if len(feed.Channel.Categories) != 2 {
+		t.Fatalf("expected 2 categories got %v", len(feed.Channel.Categories))
+	}
+	for i, want := range []string{"Technology", "News"} {
+		if feed.Channel.Categories[i].Text != want {
+			t.Errorf("expected %v got %v", want, feed.Channel.Categories[i].Text)
+		}
+	}
+}
+
+func TestCategoryInvalid(t *testing.T) {
+	feed := &Feed{
+		Channel: &Channel{},
+	}
+
+	if err := Category("")(feed); !errors.Is(err, ErrInvalidCategory) {
+		t.Errorf("expected ErrInvalidCategory, got %v", err)
+	}
+
+	if err := Category("Technology", "")(feed); !errors.Is(err, ErrInvalidCategory) {
+		t.Errorf("expected ErrInvalidCategory for empty subcategory, got %v", err)
+	}
+
+	if len(feed.Channel.Categories) != 0 {
+		t.Errorf("expected no categories to be added, got %v", len(feed.Channel.Categories))
+	}
+}
+
 func TestImageInvalid(t *testing.T) {
 	feed := &Feed{
 		Channel: &Channel{},

--- a/podcast_test.go
+++ b/podcast_test.go
@@ -283,6 +283,34 @@ func TestContainsImageElement(t *testing.T) {
 	}
 }
 
+func TestContainsCategoryElement(t *testing.T) {
+	podcast := &Podcast{}
+	data, err := getPodcastXML(podcast, Category("Technology"))
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	want := `<itunes:category text="Technology"></itunes:category>`
+	if !strings.Contains(data, want) {
+		t.Errorf("expected %v to contain %v", data, want)
+	}
+}
+
+func TestContainsNestedCategoryElement(t *testing.T) {
+	podcast := &Podcast{}
+	data, err := getPodcastXML(podcast, Category("Society & Culture", "Documentary"))
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	want := strings.Join([]string{
+		`<itunes:category text="Society &amp; Culture">`,
+		`      <itunes:category text="Documentary"></itunes:category>`,
+		`    </itunes:category>`,
+	}, "\n")
+	if !strings.Contains(data, want) {
+		t.Errorf("expected %v to contain %v", data, want)
+	}
+}
+
 func TestContainsItemElements(t *testing.T) {
 	podcast := setupPodcast()
 	feed, err := podcast.Feed()


### PR DESCRIPTION
Adds the `Category` option — item 4 from the review, and the last of the gaps found there.

## Why

`itunes:category` is **required by Apple** for a feed to be listed, and it was the one required element the options API couldn't set. The `ItunesCategory` type and `Channel.Categories` field already existed, so the only way to reach them was building the structs by hand and assigning to `feed.Channel` after `Feed()` returned — reaching past the options API for something every published feed needs.

## API

```go
func Category(name string, subcategories ...string) func(feed *Feed) error
```

```go
feed, err := podcast.Feed(
    Category("Technology"),
    Category("Society & Culture", "Documentary", "Personal Journals"),
)
```

```xml
<itunes:category text="Technology"></itunes:category>
<itunes:category text="Society &amp; Culture">
  <itunes:category text="Documentary"></itunes:category>
  <itunes:category text="Personal Journals"></itunes:category>
</itunes:category>
```

A feed may carry several categories, so calls **append** rather than replace. An empty name or subcategory returns the new `ErrInvalidCategory`, and nothing is appended when it does.

## On not validating the names

Apple publishes a fixed category taxonomy, so validating against it would catch typos. I deliberately didn't: that list changes without notice, and a library that hardcoded it would reject valid feeds the moment Apple added a category — failing closed on something the caller got right. The doc comment says to use the names the target directory publishes. Happy to add validation if you'd rather trade that off the other way.

## Notes

- Additive only — `feat:`, so release-please should cut **2.1.0**.
- Categories render before `<item>` elements, thanks to the ordering fix in #30.
- Coverage 95.9%; race suite green.
- `docs/options.md` gains a `Category` section, and the README example now includes it with regenerated sample output.
- Also corrected that doc's intro line, which still promised "performance optimizations" after #32 removed them.

Once released, Renovate will raise the bump in Athenaeum.