### PR TITLE
docs: point the README links at the v2 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # podcasts
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/CallumKerson/podcasts?style=flat-square)](https://goreportcard.com/report/github.com/CallumKerson/podcasts)
-[![Go Reference](https://pkg.go.dev/badge/github.com/CallumKerson/podcasts.svg)](https://pkg.go.dev/github.com/CallumKerson/podcasts)
+[![Go Report Card](https://goreportcard.com/badge/github.com/CallumKerson/podcasts/v2?style=flat-square)](https://goreportcard.com/report/github.com/CallumKerson/podcasts/v2)
+[![Go Reference](https://pkg.go.dev/badge/github.com/CallumKerson/podcasts/v2.svg)](https://pkg.go.dev/github.com/CallumKerson/podcasts/v2)
 [![Release](https://img.shields.io/github/release/CallumKerson/podcasts.svg?style=flat-square)](https://github.com/CallumKerson/podcasts/releases/latest)
 
 Podcast generator written in Go.
@@ -14,7 +14,7 @@ go get github.com/CallumKerson/podcasts/v2
 
 ## Go Docs
 
-[https://godoc.org/github.com/CallumKerson/podcasts](https://godoc.org/github.com/CallumKerson/podcasts)
+[https://pkg.go.dev/github.com/CallumKerson/podcasts/v2](https://pkg.go.dev/github.com/CallumKerson/podcasts/v2)
 
 ## Example usage
 


### PR DESCRIPTION
Follow-up to the 2.0.0 release: the README header still described the v1 module.

## Changes

| Link | Before | After |
|---|---|---|
| Go Report Card | `…/podcasts` | `…/podcasts/v2` |
| Go Reference | `…/podcasts` | `…/podcasts/v2` |
| Go Docs section | `godoc.org/…/podcasts` | `pkg.go.dev/…/podcasts/v2` |

The Go Reference badge and report card were describing a module path that no longer receives changes, so neither reflected anything released since 2.0.0. The Go Docs link also still pointed at godoc.org, which has redirected to pkg.go.dev for years and can't serve v2 docs at all.

The **Release** badge is deliberately left alone — it reads the repository, not the module, so the major version doesn't affect it.

## Verified

All four new URLs return 200, and pkg.go.dev is already serving the v2 docs:

```
https://pkg.go.dev/github.com/CallumKerson/podcasts/v2                    200
https://pkg.go.dev/badge/github.com/CallumKerson/podcasts/v2.svg          200
https://goreportcard.com/report/github.com/CallumKerson/podcasts/v2       200
https://goreportcard.com/badge/github.com/CallumKerson/podcasts/v2?…      200
```

I also swept the repo for other stale references — the only remaining non-`/v2` mention is the compare URL in `CHANGELOG.md`, which is a repository URL generated by release-please and correct as-is.

## Note

Branched from `main`, not from #37 — the changed lines don't overlap, so the two merge in either order.